### PR TITLE
Add label typography and color controls

### DIFF
--- a/src/Widget.php
+++ b/src/Widget.php
@@ -335,16 +335,56 @@ class Widget extends Widget_Base {
 			)
 		);
 
-		$this->add_group_control(
-			Group_Control_Box_Shadow::get_type(),
-			array(
-				'name'     => 'form_box_shadow',
-				'selector' => '{{WRAPPER}} .' . self::ELEMENT_KEY,
-			)
-		);
+                $this->add_group_control(
+                        Group_Control_Box_Shadow::get_type(),
+                        array(
+                                'name'     => 'form_box_shadow',
+                                'selector' => '{{WRAPPER}} .' . self::ELEMENT_KEY,
+                        )
+                );
 
-		$this->end_controls_section();
-	}
+               $this->end_controls_section();
+
+               $this->start_controls_section(
+                       'section_labels',
+                       array(
+                               'label' => __( 'Labels', 'gk-gravity-forms-elementor-widget' ),
+                               'tab'   => Controls_Manager::TAB_STYLE,
+                       )
+               );
+
+               $this->add_group_control(
+                       Group_Control_Typography::get_type(),
+                       array(
+                               'name'     => 'label_typography',
+                               'selector' => '{{WRAPPER}} .gk-gravity-form .gfield_label',
+                       )
+               );
+
+               $this->add_control(
+                       'label_color',
+                       array(
+                               'label'     => __( 'Text Color', 'gk-gravity-forms-elementor-widget' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .gk-gravity-form .gfield_label' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
+               $this->add_control(
+                       'required_color',
+                       array(
+                               'label'     => __( 'Required Color', 'gk-gravity-forms-elementor-widget' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .gk-gravity-form .gfield_required' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
+               $this->end_controls_section();
+        }
 
 	/**
 	 * Renders Gravity Forms widget output on the frontend.


### PR DESCRIPTION
## Summary
- add Labels style section for Gravity Forms widget
- allow customizing label typography and colors for field labels and required indicator

## Testing
- `php -l src/Widget.php`


------
https://chatgpt.com/codex/tasks/task_b_68bd0547b4c4832c8cbfb766d02a59ef