### PR TITLE
Avoid fatal error when Elementor is missing

### DIFF
--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -18,7 +18,11 @@ use Elementor\Widget_Base;
 use GFAPI;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+        exit; // Exit if accessed directly.
+}
+
+if ( ! class_exists( Widget_Base::class ) ) {
+        return;
 }
 
 /**

--- a/stoke-gf-elementor.php
+++ b/stoke-gf-elementor.php
@@ -22,8 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 const MIN_GF_VERSION = '2.7.15';
 
-require_once plugin_dir_path( __FILE__ ) . 'includes/Widget.php';
-
 /**
  * Check if Gravity Forms is installed and activated, and if the minimum required version is met.
  *
@@ -41,18 +39,20 @@ function meets_gravity_forms_requirements() {
 add_action(
     'elementor/widgets/register',
     function ( $widgets_manager ) {
-		if ( ! meets_gravity_forms_requirements() ) {
-			return;
-		}
+                if ( ! meets_gravity_forms_requirements() ) {
+                        return;
+                }
 
-		// Register widget.
-		$widgets_manager->register( new Widget() );
+                require_once plugin_dir_path( __FILE__ ) . 'includes/Widget.php';
+
+                // Register widget.
+                $widgets_manager->register( new Widget() );
 
                 add_action(
                         'elementor/editor/after_enqueue_styles',
                         array( Widget::class, 'enqueue_editor_styles' )
                 );
-	}
+        }
 );
 
 /*


### PR DESCRIPTION
## Summary
- Defer loading of the Gravity Forms Elementor widget until Elementor is available and Gravity Forms requirements are met.
- Add guard to prevent widget definition when `Elementor\Widget_Base` is unavailable, avoiding activation fatals.

## Testing
- `php -l stoke-gf-elementor.php`
- `php -l includes/Widget.php`


------
https://chatgpt.com/codex/tasks/task_b_68bd219a4144832ca3702ae6d9d5150d