### PR TITLE
Fix settings page link and submenu position

### DIFF
--- a/includes/FieldShortcodes.php
+++ b/includes/FieldShortcodes.php
@@ -149,7 +149,8 @@ class FieldShortcodes {
             esc_html__( 'GF Field Shortcodes', 'stoke-gf-elementor' ),
             'manage_options',
             'stkc-gf-field-shortcodes',
-            [ __CLASS__, 'render_page' ]
+            [ __CLASS__, 'render_page' ],
+            10
         );
     }
 

--- a/stoke-gf-elementor.php
+++ b/stoke-gf-elementor.php
@@ -24,6 +24,19 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/FieldShortcodes.php';
 
 const MIN_GF_VERSION = '2.7.15';
 
+// Add a settings link on the plugins page.
+add_filter(
+    'plugin_action_links_' . plugin_basename( __FILE__ ),
+    function ( $links ) {
+        $links[] = sprintf(
+            '<a href="%s">%s</a>',
+            esc_url( admin_url( 'admin.php?page=stkc-gf-field-shortcodes' ) ),
+            esc_html__( 'Settings', 'stoke-gf-elementor' )
+        );
+        return $links;
+    }
+);
+
 /**
  * Check if Gravity Forms is installed and activated, and if the minimum required version is met.
  *


### PR DESCRIPTION
## Summary
- Add Settings link that directs to the correct admin.php page to prevent 404 errors
- Place GF Field Shortcodes menu at position 10 in Gravity Forms submenu

## Testing
- `php -l includes/FieldShortcodes.php`
- `php -l stoke-gf-elementor.php`


------
https://chatgpt.com/codex/tasks/task_b_68bd49bdc184832c9105d5c76a9008f2