### PR TITLE
Fix settings page link and submenu position

### DIFF
--- a/includes/FieldShortcodes.php
+++ b/includes/FieldShortcodes.php
@@ -16,7 +16,8 @@ class FieldShortcodes {
      */
     public static function init() {
         add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
-        add_action( 'admin_menu', [ __CLASS__, 'register_menu' ] );
+        // Register the menu late so it appears after other Gravity Forms items.
+        add_action( 'admin_menu', [ __CLASS__, 'register_menu' ], 999 );
         add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_assets' ] );
         add_action( 'init', [ __CLASS__, 'register_shortcodes' ] );
     }

--- a/stoke-gf-elementor.php
+++ b/stoke-gf-elementor.php
@@ -24,6 +24,19 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/FieldShortcodes.php';
 
 const MIN_GF_VERSION = '2.7.15';
 
+// Add a settings link on the plugins page.
+add_filter(
+    'plugin_action_links_' . plugin_basename( __FILE__ ),
+    function ( $links ) {
+        $links[] = sprintf(
+            '<a href="%s">%s</a>',
+            esc_url( admin_url( 'admin.php?page=gf_edit_forms&view=stkc-gf-field-shortcodes' ) ),
+            esc_html__( 'Settings', 'stoke-gf-elementor' )
+        );
+        return $links;
+    }
+);
+
 /**
  * Check if Gravity Forms is installed and activated, and if the minimum required version is met.
  *


### PR DESCRIPTION
## Summary
- Register GF Field Shortcodes menu late so it appears last under Gravity Forms
- Update Settings link to point to the GF edit forms view to avoid 404s

## Testing
- `php -l includes/FieldShortcodes.php`
- `php -l stoke-gf-elementor.php`


------
https://chatgpt.com/codex/tasks/task_b_68bd49bdc184832c9105d5c76a9008f2