### PR TITLE
Group shortcode previews by form

### DIFF
--- a/assets/field-shortcodes.js
+++ b/assets/field-shortcodes.js
@@ -15,26 +15,34 @@ jQuery(function($){
     }
 
     function buildPreview(){
-        var parts = [];
-        var scs   = [];
+        var formParts = {};
+        var scs       = [];
         $('.stkc-gf-mappings tbody tr').each(function(){
             var $row  = $(this);
             var form  = $.trim($row.find('input[name$="[form_id]"]').val());
             var field = $.trim($row.find('input[name$="[field_id]"]').val());
             var tag   = $.trim($row.find('input[name$="[tag]"]').val());
             if(form && field){
-                parts.push('f'+form+'_'+field+'={Field:'+field+'}');
+                formParts[form] = formParts[form] || [];
+                formParts[form].push('f'+form+'_'+field+'={Field:'+field+'}');
             }
             if(tag){
                 scs.push('['+tag+']');
             }
         });
-        var preview = '?eid={entry_id}';
-        if(parts.length){
-            preview += '&'+parts.join('&');
-        }
-        $('#stkc-gf-sc-example code').text(preview);
-        $('#stkc-gf-sc-example .stkc-copy').attr('data-copy', preview);
+        var $example = $('#stkc-gf-sc-example');
+        $example.empty();
+        $.each(formParts, function(fid, parts){
+            var preview = '?eid={entry_id}';
+            if(parts.length){
+                preview += '&'+parts.join('&');
+            }
+            var $p = $('<p class="description"></p>');
+            $p.append($('<code></code>').text(preview));
+            $p.append(' ');
+            $p.append($('<button type="button" class="button button-small stkc-copy"></button>').text('Copy').attr('data-copy', preview));
+            $example.append($p);
+        });
         $('#stkc-gf-sc-shortcodes').text(scs.join(' '));
     }
 

--- a/includes/FieldShortcodes.php
+++ b/includes/FieldShortcodes.php
@@ -277,23 +277,28 @@ class FieldShortcodes {
                     </tbody>
                 </table>
                 <?php
-                $parts      = [];
+                $form_parts = [];
                 $shortcodes = [];
                 foreach ( $mappings as $m ) {
-                    $f = isset( $m['form_id'] ) ? (int) $m['form_id'] : 0;
+                    $f   = isset( $m['form_id'] ) ? (int) $m['form_id'] : 0;
                     $fld = isset( $m['field_id'] ) ? (string) $m['field_id'] : '';
                     if ( $f && '' !== $fld ) {
-                        $parts[] = sprintf( 'f%d_%s={Field:%s}', $f, $fld, $fld );
+                        $form_parts[ $f ][] = sprintf( 'f%d_%s={Field:%s}', $f, $fld, $fld );
                     }
                     if ( ! empty( $m['tag'] ) ) {
                         $shortcodes[] = '[' . preg_replace( '/[^A-Za-z0-9_]/', '', $m['tag'] ) . ']';
                     }
                 }
-                $preview    = '?eid={entry_id}' . ( $parts ? '&' . implode( '&', $parts ) : '' );
                 $sc_display = implode( ' ', $shortcodes );
                 ?>
-                <p id="stkc-gf-sc-example" class="description"><code><?php echo esc_html( $preview ); ?></code> <button type="button" class="button button-small stkc-copy" data-copy="<?php echo esc_attr( $preview ); ?>"><?php esc_html_e( 'Copy', 'stoke-gf-elementor' ); ?></button></p>
-                <p class="description"><?php esc_html_e( 'Copy this query and add it to the end of your confirmation page URL.', 'stoke-gf-elementor' ); ?></p>
+                <div id="stkc-gf-sc-example">
+                    <?php foreach ( $form_parts as $fid => $parts ) :
+                        $preview = '?eid={entry_id}' . ( $parts ? '&' . implode( '&', $parts ) : '' );
+                        ?>
+                        <p class="description"><code><?php echo esc_html( $preview ); ?></code> <button type="button" class="button button-small stkc-copy" data-copy="<?php echo esc_attr( $preview ); ?>"><?php esc_html_e( 'Copy', 'stoke-gf-elementor' ); ?></button></p>
+                    <?php endforeach; ?>
+                </div>
+                <p class="description"><?php esc_html_e( 'Copy each query and add it to the end of your confirmation page URL.', 'stoke-gf-elementor' ); ?></p>
                 <p class="description"><?php esc_html_e( 'Use these shortcodes in your confirmation page to display the submitted values:', 'stoke-gf-elementor' ); ?> <span id="stkc-gf-sc-shortcodes"><?php echo esc_html( $sc_display ); ?></span></p>
                 <p><button type="button" class="button stkc-add-row"><?php esc_html_e( 'Add Mapping', 'stoke-gf-elementor' ); ?></button></p>
                 <?php submit_button(); ?>


### PR DESCRIPTION
## Summary
- show separate example query strings for each selected Gravity Form
- support grouped shortcode previews in admin via JS

## Testing
- `node --check assets/field-shortcodes.js`
- `php -l includes/FieldShortcodes.php`


------
https://chatgpt.com/codex/tasks/task_b_68bd50a10ad4832c980c1f807417eb5f