### PR TITLE
Rename plugin and add button hover background option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Stoke GF Elementor
+# Stoke Gravity Forms for Elementor
 
-=== Stoke GF Elementor ===
+=== Stoke Gravity Forms for Elementor ===
 Contributors: stokedesignco
 Tags: gravity forms, elementor, widget, form builder
 Requires at least: 5.0
@@ -10,11 +10,11 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Stoke GF Elementor lets you embed Gravity Forms into Elementor layouts with a customizable widget.
+Stoke Gravity Forms for Elementor lets you embed Gravity Forms into Elementor layouts with a customizable widget.
 
 == Description ==
 
-**Stoke GF Elementor** adds a widget to Elementor so you can select and style any Gravity Form without shortcodes.
+**Stoke Gravity Forms for Elementor** adds a widget to Elementor so you can select and style any Gravity Form without shortcodes.
 
 With this plugin, you can:
 
@@ -26,7 +26,7 @@ With this plugin, you can:
 
 1. Upload the plugin files to the `/wp-content/plugins/stoke-gf-elementor/` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to your Elementor page editor, search for "Stoke GF Elementor" in the Elementor widget panel, and drag the widget into your layout.
+3. Go to your Elementor page editor, search for "Stoke Gravity Forms for Elementor" in the Elementor widget panel, and drag the widget into your layout.
 4. Select the Gravity Form you want to display and customize the settings as desired.
 
 == Frequently Asked Questions ==
@@ -40,7 +40,7 @@ This plugin supports the basic functionality of displaying and customizing Gravi
 == Changelog ==
 
 = 1.0.0 =
-Initial release of Stoke GF Elementor.
+Initial release of Stoke Gravity Forms for Elementor.
 
 == Credits ==
 This plugin was developed by Stoke Design Co. Gravity Forms is a product of Rocketgenius, Inc. Elementor is a product of Elementor Ltd. This plugin is not affiliated with or endorsed by Rocketgenius, Inc. or Elementor Ltd.

--- a/includes/FieldShortcodes.php
+++ b/includes/FieldShortcodes.php
@@ -146,8 +146,8 @@ class FieldShortcodes {
     public static function register_menu() {
         add_submenu_page(
             'gf_edit_forms',
-            esc_html__( 'GF Field Shortcodes', 'stoke-gf-elementor' ),
-            esc_html__( 'GF Field Shortcodes', 'stoke-gf-elementor' ),
+            esc_html__( 'Field Shortcodes', 'stoke-gf-elementor' ),
+            esc_html__( 'Field Shortcodes', 'stoke-gf-elementor' ),
             'manage_options',
             'stkc-gf-field-shortcodes',
             [ __CLASS__, 'render_page' ],
@@ -200,7 +200,7 @@ class FieldShortcodes {
 
         ?>
         <div class="wrap">
-            <h1><?php esc_html_e( 'GF Field Shortcodes', 'stoke-gf-elementor' ); ?></h1>
+            <h1><?php esc_html_e( 'Field Shortcodes', 'stoke-gf-elementor' ); ?></h1>
             <form method="post" action="options.php">
                 <?php
                 settings_fields( 'stkc_content' );

--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -56,10 +56,10 @@ class Widget extends Widget_Base {
 	 * @access public
 	 *
 	 * @return string Widget title.
-	 */
-	public function get_title() {
-		return __( 'Stoke GF Elementor', 'stoke-gf-elementor' );
-	}
+        */
+        public function get_title() {
+                return __( 'Stoke Gravity Forms for Elementor', 'stoke-gf-elementor' );
+        }
 
 	/**
 	 * Retrieves the list of categories the Gravity Forms widget belongs to.
@@ -979,6 +979,15 @@ $this->end_controls_section();
                         array(
                                 'name'     => 'buttons_background',
                                 'selector' => $buttons,
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Background::get_type(),
+                        array(
+                                'name'     => 'buttons_hover_background',
+                                'label'    => __( 'Hover Background', 'stoke-gf-elementor' ),
+                                'selector' => str_replace( ', ', ':hover, ', $buttons ) . ':hover',
                         )
                 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Stoke GF Elementor ===
+=== Stoke Gravity Forms for Elementor ===
 Contributors: stokedesignco
 Tags: gravity forms, elementor, widget, form builder
 Requires at least: 5.0
@@ -8,11 +8,11 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Stoke GF Elementor lets you embed Gravity Forms into Elementor layouts with a customizable widget.
+Stoke Gravity Forms for Elementor lets you embed Gravity Forms into Elementor layouts with a customizable widget.
 
 == Description ==
 
-**Stoke GF Elementor** adds a widget to Elementor so you can select and style any Gravity Form without shortcodes.
+**Stoke Gravity Forms for Elementor** adds a widget to Elementor so you can select and style any Gravity Form without shortcodes.
 
 With this plugin, you can:
 
@@ -24,7 +24,7 @@ With this plugin, you can:
 
 1. Upload the plugin files to the `/wp-content/plugins/stoke-gf-elementor/` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to your Elementor page editor, search for "Stoke GF Elementor" in the Elementor widget panel, and drag the widget into your layout.
+3. Go to your Elementor page editor, search for "Stoke Gravity Forms for Elementor" in the Elementor widget panel, and drag the widget into your layout.
 4. Select the Gravity Form you want to display and customize the settings as desired.
 
 == Frequently Asked Questions ==
@@ -38,7 +38,7 @@ This plugin supports the basic functionality of displaying and customizing Gravi
 == Changelog ==
 
 = 1.0.0 =
-Initial release of Stoke GF Elementor.
+Initial release of Stoke Gravity Forms for Elementor.
 
 == Credits ==
 This plugin was developed by Stoke Design Co. Gravity Forms is a product of Rocketgenius, Inc. Elementor is a product of Elementor Ltd. This plugin is not affiliated with or endorsed by Rocketgenius, Inc. or Elementor Ltd.

--- a/stoke-gf-elementor.php
+++ b/stoke-gf-elementor.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name:         Stoke GF Elementor
+ * Plugin Name:         Stoke Gravity Forms for Elementor
  * Plugin URI:          https://stokedesign.co/sandbox
- * Description:         Allows Gravity forms to easily be inserted and styled in Elementor.
+ * Description:         Allows Gravity Forms to easily be inserted and styled in Elementor.
  * Version:             1.2.0
  * Author:              Stoke Design Co
  * Author URI:          https://stokedesign.co/
@@ -87,9 +87,9 @@ add_action(
             // translators: Do not translate [version]; it is replaced with the minimum required Gravity Forms version required.
                 esc_html__( '[plugin_name] requires Gravity Forms [version] or higher. Please upgrade Gravity Forms to use this widget.', 'stoke-gf-elementor' ),
                 array(
-					'[plugin_name]' => esc_html__( 'Stoke GF Elementor', 'stoke-gf-elementor' ),
-					'[version]'     => MIN_GF_VERSION,
-                )
+                                        '[plugin_name]' => esc_html__( 'Stoke Gravity Forms for Elementor', 'stoke-gf-elementor' ),
+                                        '[version]'     => MIN_GF_VERSION,
+                                )
             )
 		);
 


### PR DESCRIPTION
## Summary
- rename plugin to **Stoke Gravity Forms for Elementor** and update documentation
- rename admin menu and settings page to "Field Shortcodes"
- add background style control for button hover states

## Testing
- `php -l includes/FieldShortcodes.php`
- `php -l includes/Widget.php`
- `php -l stoke-gf-elementor.php`


------
https://chatgpt.com/codex/tasks/task_b_68bd56eb4750832c954fcf5f3a1b56f5